### PR TITLE
Update links/references to workflows/

### DIFF
--- a/deployment/xgboost/xgboost-wine-end-to-end.ipynb
+++ b/deployment/xgboost/xgboost-wine-end-to-end.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/VertaAI/modeldb/blob/master/client/workflows/examples/xgboost.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/VertaAI/examples/blob/master/deployment/xgboost/xgboost-wine-end-to-end.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/end-to-end/xgboost/xgboost-wine-end-to-end.ipynb
+++ b/end-to-end/xgboost/xgboost-wine-end-to-end.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a href=\"https://colab.research.google.com/github/VertaAI/modeldb/blob/master/client/workflows/examples/xgboost.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/VertaAI/examples/blob/master/end-to-end/xgboost/xgboost-wine-end-to-end.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {


### PR DESCRIPTION
## Impact and Context

https://github.com/VertaAI/modeldb/pull/2764 is removing `modeldb/client/workflows/`; this PR updates links/references to point at equivalent notebooks in https://github.com/VertaAI/examples.

## Risks and Area of Effect

See https://github.com/VertaAI/modeldb/pull/2764.

## Testing

—

## How to Revert

Revert this PR.
