### PR TITLE
docs: Make census-end-to-end run more smoothly

### DIFF
--- a/deployment/sklearn/sklearn-census-end-to-end.ipynb
+++ b/deployment/sklearn/sklearn-census-end-to-end.ipynb
@@ -275,7 +275,7 @@
     "\n",
     "model_version_v1 = registered_model.create_standard_model_from_sklearn(\n",
     "    model,\n",
-    "    environment=Python(requirements=[\"scikit-learn\"]),\n",
+    "    environment=Python(requirements=[\"scikit-learn\", \"pandas\"]),\n",
     "    name=\"v1\",\n",
     ")"
    ]
@@ -339,7 +339,7 @@
     "\n",
     "model_version_v2 = registered_model.create_standard_model(\n",
     "    model_cls=CensusIncomeClassifier,\n",
-    "    environment=Python(requirements=[\"scikit-learn\"]),\n",
+    "    environment=Python(requirements=[\"scikit-learn\", \"pandas\"]),\n",
     "    code_dependencies=[],\n",
     "    artifacts=artifacts_dict,\n",
     "    name=\"v2\"\n",

--- a/deployment/sklearn/sklearn-census-end-to-end.ipynb
+++ b/deployment/sklearn/sklearn-census-end-to-end.ipynb
@@ -123,10 +123,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta.dataset import S3\n",
+    "from verta.dataset import Path\n",
     "\n",
-    "dataset = client.set_dataset(name=\"Census Income S3\")\n",
-    "dataset_version = dataset.create_version(S3(\"s3://verta-starter\"))"
+    "dataset = client.set_dataset(name=\"Census Income\")\n",
+    "dataset_version = dataset.create_version(\n",
+    "    Path(train_data_filename),  # could also be S3(\"s3://verta-starter\")\n",
+    ")"
    ]
   },
   {

--- a/deployment/sklearn/sklearn-census-end-to-end.ipynb
+++ b/deployment/sklearn/sklearn-census-end-to-end.ipynb
@@ -408,7 +408,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -422,7 +422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/deployment/sklearn/sklearn-census-end-to-end.ipynb
+++ b/deployment/sklearn/sklearn-census-end-to-end.ipynb
@@ -263,35 +263,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.1 Register from the model object\n",
-    "#### If you are in the same file where you have the model object handy, use the code below to package the model"
+    "### Register a serialized version of the model using the VertaModelBase"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from verta.environment import Python\n",
-    "\n",
-    "model_version_v1 = registered_model.create_standard_model_from_sklearn(\n",
-    "    model,\n",
-    "    environment=Python(requirements=[\"scikit-learn\", \"pandas\"]),\n",
-    "    name=\"v1\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.2 (OR) Register a serialized version of the model using the VertaModelBase"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,18 +310,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "from verta.environment import Python\n",
     "\n",
-    "model_version_v2 = registered_model.create_standard_model(\n",
+    "model_version = registered_model.create_standard_model(\n",
     "    model_cls=CensusIncomeClassifier,\n",
     "    environment=Python(requirements=[\"scikit-learn\", \"pandas\"]),\n",
     "    code_dependencies=[],\n",
     "    artifacts=artifacts_dict,\n",
-    "    name=\"v2\"\n",
+    "    name=\"v1\",\n",
     ")"
    ]
   },
@@ -357,36 +334,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
     "census_endpoint = client.get_or_create_endpoint(\"census-sklearn\")\n",
-    "census_endpoint.update(model_version_v1, wait=True)"
+    "census_endpoint.update(model_version, wait=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "deployed_model = census_endpoint.get_deployed_model()\n",
-    "deployed_model.predict(X_test.values.tolist()[:5])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "census_endpoint.update(model_version_v2, wait=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/deployment/sklearn/sklearn-census-end-to-end.ipynb
+++ b/deployment/sklearn/sklearn-census-end-to-end.ipynb
@@ -335,9 +335,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from verta.environment import Python\n",
+    "\n",
     "model_version_v2 = registered_model.create_standard_model(\n",
     "    model_cls=CensusIncomeClassifier,\n",
     "    environment=Python(requirements=[\"scikit-learn\"]),\n",
+    "    code_dependencies=[],\n",
     "    artifacts=artifacts_dict,\n",
     "    name=\"v2\"\n",
     ")"

--- a/deployment/xgboost-sklearn/xgboost-sklearn-census-end-to-end.ipynb
+++ b/deployment/xgboost-sklearn/xgboost-sklearn-census-end-to-end.ipynb
@@ -24,6 +24,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# restart your notebook if prompted on Colab\n",
+    "!python -m pip install verta\n",
+    "!python -m pip install wget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "\n",
     "import warnings\n",
@@ -34,8 +45,6 @@
     "import itertools\n",
     "import os\n",
     "import time\n",
-    "\n",
-    "import six\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -56,19 +65,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# restart your notebook if prompted on Colab\n",
-    "try:\n",
-    "    import verta\n",
-    "except ImportError:\n",
-    "    !pip install verta"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [],
@@ -81,9 +77,10 @@
     "# os.environ['VERTA_HOST'] = \n",
     "\n",
     "from verta import Client\n",
+    "\n",
     "PROJECT_NAME = \"Census\"\n",
     "EXPERIMENT_NAME = \"sklearn + xgboost\"\n",
-    "client = Client(os.environ['VERTA_HOST'])\n",
+    "client = Client()\n",
     "proj = client.set_project(PROJECT_NAME)\n",
     "expt = client.set_experiment(EXPERIMENT_NAME)"
    ]
@@ -108,19 +105,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import wget\n",
-    "except ImportError:\n",
-    "    !pip install wget  # you may need pip3\n",
-    "    import wget"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import wget\n",
+    "\n",
     "train_data_url = \"http://s3.amazonaws.com/verta-starter/census-train.csv\"\n",
     "train_data_filename = wget.detect_filename(train_data_url)\n",
     "if not os.path.isfile(train_data_filename):\n",
@@ -134,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,11 +348,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta.registry import VertaModelBase\n",
+    "from verta.registry import VertaModelBase, verify_io\n",
     "\n",
     "class CensusTwoStep(VertaModelBase):\n",
     "    def __init__(self, artifacts):\n",
@@ -375,7 +361,8 @@
     "            open(artifacts[\"hpw_model\"], \"rb\"))\n",
     "        self.income_model = cloudpickle.load(\n",
     "            open(artifacts[\"income_model\"], \"rb\"))\n",
-    "        \n",
+    "    \n",
+    "    @verify_io\n",
     "    def predict(self, batch_input):\n",
     "        import numpy as np\n",
     "        results = []\n",
@@ -383,13 +370,13 @@
     "            output = self.hpw_model.predict(one_input)\n",
     "            output = np.concatenate((np.array(one_input), np.reshape(output, (-1,1))), axis=1)\n",
     "            output = self.income_model.predict(output)\n",
-    "            results.append(output)\n",
+    "            results.append(output.tolist())\n",
     "        return results"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,12 +446,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
     "deployed_model = census_multiple_endpoint.get_deployed_model()\n",
     "deployed_model.predict([X_train_hpw.values.tolist()[:5]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "census_multiple_endpoint.delete()"
    ]
   },
   {
@@ -477,7 +473,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -491,7 +487,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/deployment/xgboost-sklearn/xgboost-sklearn-census-end-to-end.ipynb
+++ b/deployment/xgboost-sklearn/xgboost-sklearn-census-end-to-end.ipynb
@@ -409,7 +409,7 @@
     "from verta.environment import Python\n",
     "model_version = registered_model.create_standard_model(\n",
     "    model_cls=CensusTwoStep,\n",
-    "    environment=Python(requirements=[\"sklearn\", \"xgboost\"]),\n",
+    "    environment=Python(requirements=[\"sklearn\", \"pandas\", \"xgboost\"]),\n",
     "    code_dependencies=[],\n",
     "    artifacts={\n",
     "        \"hpw_model\" : hpw_model,\n",

--- a/deployment/xgboost-sklearn/xgboost-sklearn-census-end-to-end.ipynb
+++ b/deployment/xgboost-sklearn/xgboost-sklearn-census-end-to-end.ipynb
@@ -410,9 +410,10 @@
     "model_version = registered_model.create_standard_model(\n",
     "    model_cls=CensusTwoStep,\n",
     "    environment=Python(requirements=[\"sklearn\", \"xgboost\"]),\n",
+    "    code_dependencies=[],\n",
     "    artifacts={\n",
     "        \"hpw_model\" : hpw_model,\n",
-    "        \"income_model\" : income_model\n",
+    "        \"income_model\" : income_model,\n",
     "    },\n",
     "    name=\"v6\"\n",
     ")"

--- a/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
+++ b/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
@@ -275,7 +275,7 @@
     "\n",
     "model_version_v1 = registered_model.create_standard_model_from_sklearn(\n",
     "    model,\n",
-    "    environment=Python(requirements=[\"scikit-learn\"]),\n",
+    "    environment=Python(requirements=[\"scikit-learn\", \"pandas\"]),\n",
     "    name=\"v1\",\n",
     ")"
    ]
@@ -339,7 +339,7 @@
     "\n",
     "model_version_v2 = registered_model.create_standard_model(\n",
     "    model_cls=CensusIncomeClassifier,\n",
-    "    environment=Python(requirements=[\"scikit-learn\"]),\n",
+    "    environment=Python(requirements=[\"scikit-learn\", \"pandas\"]),\n",
     "    code_dependencies=[],\n",
     "    artifacts=artifacts_dict,\n",
     "    name=\"v2\"\n",

--- a/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
+++ b/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
@@ -263,35 +263,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.1 Register from the model object\n",
-    "#### If you are in the same file where you have the model object handy, use the code below to package the model"
+    "### Register a serialized version of the model using the VertaModelBase"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from verta.environment import Python\n",
-    "\n",
-    "model_version_v1 = registered_model.create_standard_model_from_sklearn(\n",
-    "    model,\n",
-    "    environment=Python(requirements=[\"scikit-learn\", \"pandas\"]),\n",
-    "    name=\"v1\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.2 (OR) Register a serialized version of the model using the VertaModelBase"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,18 +310,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
     "from verta.environment import Python\n",
     "\n",
-    "model_version_v2 = registered_model.create_standard_model(\n",
+    "model_version = registered_model.create_standard_model(\n",
     "    model_cls=CensusIncomeClassifier,\n",
     "    environment=Python(requirements=[\"scikit-learn\", \"pandas\"]),\n",
     "    code_dependencies=[],\n",
     "    artifacts=artifacts_dict,\n",
-    "    name=\"v2\"\n",
+    "    name=\"v1\"\n",
     ")"
    ]
   },
@@ -357,36 +334,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
     "census_endpoint = client.get_or_create_endpoint(\"census-sklearn\")\n",
-    "census_endpoint.update(model_version_v1, wait=True)"
+    "census_endpoint.update(model_version, wait=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "deployed_model = census_endpoint.get_deployed_model()\n",
-    "deployed_model.predict(X_test.values.tolist()[:5])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "census_endpoint.update(model_version_v2, wait=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
+++ b/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
@@ -123,10 +123,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta.dataset import S3\n",
+    "from verta.dataset import Path\n",
     "\n",
-    "dataset = client.set_dataset(name=\"Census Income S3\")\n",
-    "dataset_version = dataset.create_version(S3(\"s3://verta-starter\"))"
+    "dataset = client.set_dataset(name=\"Census Income\")\n",
+    "dataset_version = dataset.create_version(\n",
+    "    Path(train_data_filename),  # could also be S3(\"s3://verta-starter\")\n",
+    ")"
    ]
   },
   {

--- a/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
+++ b/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
@@ -408,7 +408,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -422,7 +422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,

--- a/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
+++ b/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
@@ -24,6 +24,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# restart your notebook if prompted on Colab\n",
+    "!python -m pip install verta\n",
+    "!python -m pip install wget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from __future__ import print_function\n",
     "\n",
     "import warnings\n",
@@ -34,8 +45,6 @@
     "import itertools\n",
     "import os\n",
     "import time\n",
-    "\n",
-    "import six\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -55,19 +64,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# restart your notebook if prompted on Colab\n",
-    "try:\n",
-    "    import verta\n",
-    "except ImportError:\n",
-    "    !pip install verta"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
    "outputs": [],
@@ -80,9 +76,10 @@
     "# os.environ['VERTA_HOST'] = \n",
     "\n",
     "from verta import Client\n",
+    "\n",
     "PROJECT_NAME = \"Census\"\n",
     "EXPERIMENT_NAME = \"sklearn\"\n",
-    "client = Client(os.environ['VERTA_HOST'])\n",
+    "client = Client()\n",
     "proj = client.set_project(PROJECT_NAME)\n",
     "expt = client.set_experiment(EXPERIMENT_NAME)"
    ]
@@ -107,19 +104,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    import wget\n",
-    "except ImportError:\n",
-    "    !pip install wget  # you may need pip3\n",
-    "    import wget"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import wget\n",
+    "\n",
     "train_data_url = \"http://s3.amazonaws.com/verta-starter/census-train.csv\"\n",
     "train_data_filename = wget.detect_filename(train_data_url)\n",
     "if not os.path.isfile(train_data_filename):\n",
@@ -133,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,26 +300,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from verta.registry import VertaModelBase\n",
+    "from verta.registry import VertaModelBase, verify_io\n",
     "\n",
     "class CensusIncomeClassifier(VertaModelBase):\n",
     "    def __init__(self, artifacts):\n",
     "        self.model = cloudpickle.load(open(artifacts[\"serialized_model\"], \"rb\"))\n",
     "        \n",
+    "    @verify_io\n",
     "    def predict(self, batch_input):\n",
     "        results = []\n",
     "        for one_input in batch_input:\n",
-    "            results.append(self.model.predict(one_input))\n",
+    "            results.append(self.model.predict(one_input).tolist())\n",
     "        return results"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,12 +381,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
     "deployed_model = census_endpoint.get_deployed_model()\n",
     "deployed_model.predict([X_test.values.tolist()[:5]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "census_endpoint.delete()"
    ]
   },
   {

--- a/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
+++ b/end-to-end/sklearn/sklearn-census-end-to-end.ipynb
@@ -335,9 +335,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from verta.environment import Python\n",
+    "\n",
     "model_version_v2 = registered_model.create_standard_model(\n",
     "    model_cls=CensusIncomeClassifier,\n",
     "    environment=Python(requirements=[\"scikit-learn\"]),\n",
+    "    code_dependencies=[],\n",
     "    artifacts=artifacts_dict,\n",
     "    name=\"v2\"\n",
     ")"


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->

Makes the end-to-end onboarding experience smoother.

Migrates the changes to `deployment/sklearn/sklearn-census-end-to-end.ipynb` in #16 to 

- `deployment/sklearn/sklearn-census-end-to-end.ipynb`
- `deployment/xgboost-sklearn/xgboost-sklearn-census-end-to-end.ipynb`

Also:

- use `Path()` data versioning instead of `S3()` (skips AWS credentials)
- remove `create_standard_model_from_sklearn()` (because it is unable to skip custom modules)
- skip custom modules for `create_standard_model()`
- add `pandas` to environment versioning because new fancy versions aren't compatible with the default running in our model service.
- populate model playground fields

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

—

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

I ran the notebooks and viewed the model playground to make sure they're correct.

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->

Revert this PR.