### PR TITLE
Fix: Remove init memory specs from h2o model

### DIFF
--- a/deployment/h2o/h2o-deployment.ipynb
+++ b/deployment/h2o/h2o-deployment.ipynb
@@ -155,7 +155,7 @@
     "        import h2o\n",
     "        import jdk\n",
     "        # Based on our testing, making predictions requires about this much memory to avoid \"Out Of Memory\" crashes\n",
-    "        h2o.init(min_mem_size=\"250M\")\n",
+    "        h2o.init()\n",
     "        self.model = h2o.load_model(artifacts[\"serialized_model\"])\n",
     "    \n",
     "    @verify_io\n",


### PR DESCRIPTION
<!-- Title of the PR must comply with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines. --> 
<!-- Title should include the JIRA ticket in square brackets after the conventional commit prefix. This will automatically link the PR in JIRA. -->
<!-- Example: "fix: [JIRA-123] Allow creation of groups with no members" -->

## Impact and Context
<!-- Brief description of why these changes are necessary. Don't rewrite the entire Jira ticket. -->
It's more important to update the _endpoint's_ memory than the h2o's initial memory. It'll default to 25% of the available memory.

## Risks and Area of Effect
<!--
  Describe both risk (how likely this is to break) and area of effect (how wide potential breakages could reach).
  These should be smaller scale than those documented in a design doc.
-->

## Testing
<!-- Explain how this contribution has been tested, e.g. what tests were added and where they have been run. -->

## How to Revert
<!-- List steps required to revert this change. For example, note if we'd need to revert liquibase changes. -->
