### PR TITLE
docs: Fix spaCy notebook

### DIFF
--- a/deployment/spacy/text-classification-spacy.ipynb
+++ b/deployment/spacy/text-classification-spacy.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Deploying a spaCy (text classificastion) model on Verta\n",
+    "# Deploying a spaCy 2 (text classificastion) model on Verta\n",
     "\n",
     "Within Verta, a \"Model\" can be any arbitrary function: a traditional ML model (e.g., sklearn, PyTorch, TF, etc); a function (e.g., squaring a number, making a DB function etc.); or a mixture of the above (e.g., pre-processing code, a DB call, and then a model application.) See more [here](https://docs.verta.ai/verta/registry/concepts).\n",
     "\n",
@@ -45,6 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!python -m pip install 'spacy<3'\n",
     "!python -m spacy download en"
    ]
   },
@@ -97,7 +98,7 @@
     "# import os\n",
     "# os.environ['VERTA_EMAIL'] = \n",
     "# os.environ['VERTA_DEV_KEY'] = \n",
-    "# os.environ['VERTA_HOST']"
+    "# os.environ['VERTA_HOST'] = "
    ]
   },
   {
@@ -536,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

This notebook was designed with spaCy v2, so we need to constrain the install.

This also ensures we download `thinc<8`, which fixes

```
ModuleNotFoundError: No module named 'thinc.extra.datasets'
```

## Risks and Area of Effect

—

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

I ran the notebook to completion in Colab: https://colab.research.google.com/github/VertaAI/examples/blob/liu/spacy/deployment/spacy/text-classification-spacy.ipynb#scrollTo=6Gz59lqXepzx

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.