### PR TITLE
fix: add enpoint deployment code to tfhub-text-classication.ipynb

### DIFF
--- a/deployment/tfhub/tfhub-text-classification.ipynb
+++ b/deployment/tfhub/tfhub-text-classification.ipynb
@@ -63,8 +63,8 @@
     "!pip install verta\n",
     "!pip install matplotlib==3.1.1\n",
     "# for macos\n",
-    "# !pip install tensorflow-macos\n",
-    "# !pip install -U tensorflow-hub\n",
+    "# !pip install tensorflow-macos==2.11.0\n",
+    "# !pip install -U tensorflow-hub==0.12.0\n",
     "# else\n",
     "!pip install tensorflow==2.0.0-beta1\n",
     "!pip install -U tensorflow-hub==0.5.0\n",
@@ -84,35 +84,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HOST = 'app.verta.ai'\n",
-    "\n",
-    "PROJECT_NAME = 'Text-Classification'\n",
-    "EXPERIMENT_NAME = 'basic-clf'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# import os\n",
-    "# os.environ['VERTA_EMAIL'] = \n",
-    "# os.environ['VERTA_DEV_KEY'] = "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from verta import Client\n",
     "from verta.utils import ModelAPI\n",
     "\n",
-    "client = Client(HOST, use_git=False)\n",
+    "# Use local env vars or uncomment and fill out the lines below:\n",
+    "# os.environ['VERTA_EMAIL'] = ''\n",
+    "# os.environ['VERTA_DEV_KEY'] = ''\n",
+    "# os.environ['VERTA_HOST'] = ''\n",
     "\n",
-    "proj = client.set_project(PROJECT_NAME)\n",
+    "client: Client = Client()\n",
+    "\n",
+    "# Naming convention to be used for this example\n",
+    "NAME: str = 'tfhub-text-classification-example'\n",
+    "\n",
+    "EXPERIMENT_NAME: str = 'gnews-swivel-20dim-clf'\n",
+    "\n",
+    "proj = client.set_project(NAME)\n",
     "expt = client.set_experiment(EXPERIMENT_NAME)\n",
     "run = client.set_experiment_run()"
    ]
@@ -506,6 +493,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "registered_model = client.get_or_create_registered_model(\n",
+    "    name=\"text-clf-example\", labels=[\"nlp\", \"tensorflow\"])"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -519,16 +516,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "registered_model = client.get_or_create_registered_model(\n",
-    "    name=\"text-clf\", labels=[\"nlp\", \"tensorflow\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# save model locally\n",
+    "\n",
+    "# Uncomment if tf saved model format\n",
+    "# model.save('tfhub_text.tf_saved_model', save_format='tf')\n",
+    "\n",
+    "# Uncomment if h5 format\n",
     "model.save('tfhub_text.h5', save_format='h5')"
    ]
   },
@@ -544,8 +537,10 @@
     "    def __init__(self, artifacts):\n",
     "        import tensorflow as tf\n",
     "        import tensorflow_hub as tfhub\n",
+    "\n",
+    "        # custom_objects need to be defined while loading/deserializing the model\n",
     "        self.model = tf.keras.models.load_model(\n",
-    "            artifacts[\"tf-clf\"], custom_objects={'KerasLayer': tfhub.KerasLayer})\n",
+    "            artifacts[\"text_clf\"], custom_objects={'KerasLayer': tfhub.KerasLayer})\n",
     "    \n",
     "    def predict(self, input_data):\n",
     "        if type(input_data) == list:\n",
@@ -560,9 +555,15 @@
    "outputs": [],
    "source": [
     "# test locally\n",
-    "artifacts = {\"tf-clf\" : \"tfhub_text.h5\"}\n",
-    "mnist_model1 = TFHubModel(artifacts)\n",
-    "mnist_model1.predict(list(sample_pred))"
+    "\n",
+    "# Uncomment if tf saved model format\n",
+    "# artifacts = {\"text_clf\" : \"tfhub_text.tf_saved_model/\"}\n",
+    "\n",
+    "# Uncomment if h5 format\n",
+    "artifacts = {\"text_clf\" : \"tfhub_text.h5\"}\n",
+    "\n",
+    "tfhub_text_model1 = TFHubModel(artifacts)\n",
+    "tfhub_text_model1.predict(list(sample_pred))"
    ]
   },
   {
@@ -571,7 +572,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# register model\n",
+    "# upload model to registry\n",
     "from verta.environment import Python\n",
     "\n",
     "model_version_from_cls = registered_model.create_standard_model(\n",
@@ -596,8 +597,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# create endpoint\n",
-    "tftext_endpoint = client.get_or_create_endpoint(\"tf-text-clf-v1\")\n",
+    "# create endpoint and update to deploy model\n",
+    "tftext_endpoint = client.get_or_create_endpoint(\"tf-text-clf-example-v1\")\n",
     "tftext_endpoint.update(model_version_from_cls, wait=True)"
    ]
   },
@@ -618,7 +619,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# delete endpoint after use\n",
+    "# delete endpoint\n",
     "tftext_endpoint.delete()"
    ]
   }

--- a/deployment/tfhub/tfhub-text-classification.ipynb
+++ b/deployment/tfhub/tfhub-text-classification.ipynb
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
@@ -62,8 +62,12 @@
     "# Python 3.6\n",
     "!pip install verta\n",
     "!pip install matplotlib==3.1.1\n",
+    "# for macos\n",
+    "# !pip install tensorflow-macos\n",
+    "# !pip install -U tensorflow-hub\n",
+    "# else\n",
     "!pip install tensorflow==2.0.0-beta1\n",
-    "!pip install tensorflow-hub==0.5.0\n",
+    "!pip install -U tensorflow-hub==0.5.0\n",
     "!pip install tensorflow-datasets==1.0.2"
    ]
   },
@@ -76,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -170,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -202,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -226,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -253,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -279,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -313,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -335,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -362,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -382,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -410,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -443,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -491,6 +495,131 @@
    "source": [
     "sample_pred = np.array([\"The new Spiderman movie is a fun watch. Loved it!\"])\n",
     "model.predict(sample_pred)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Registering the model"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the model uses CustomObject (i.e KerasLayer from tensorflow_hub) we have to register the model into the catalogue using a serialized version of the model using the VertaModelBase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "registered_model = client.get_or_create_registered_model(\n",
+    "    name=\"text-clf\", labels=[\"nlp\", \"tensorflow\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.save('tfhub_text.h5', save_format='h5')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from verta.registry import VertaModelBase\n",
+    "\n",
+    "class TFHubModel(VertaModelBase):\n",
+    "    def __init__(self, artifacts):\n",
+    "        import tensorflow as tf\n",
+    "        import tensorflow_hub as tfhub\n",
+    "        self.model = tf.keras.models.load_model(\n",
+    "            artifacts[\"tf-clf\"], custom_objects={'KerasLayer': tfhub.KerasLayer})\n",
+    "    \n",
+    "    def predict(self, input_data):\n",
+    "        if type(input_data) == list:\n",
+    "            input_data = np.array(input_data)\n",
+    "        return list(self.model.predict(input_data).reshape((-1)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# test locally\n",
+    "artifacts = {\"tf-clf\" : \"tfhub_text.h5\"}\n",
+    "mnist_model1 = TFHubModel(artifacts)\n",
+    "mnist_model1.predict(list(sample_pred))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# register model\n",
+    "from verta.environment import Python\n",
+    "\n",
+    "model_version_from_cls = registered_model.create_standard_model(\n",
+    "    TFHubModel, \n",
+    "    environment=Python([\"tensorflow\", \"tensorflow-hub\"]),\n",
+    "    name=\"v1\", \n",
+    "    artifacts=artifacts\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy the Model to Endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create endpoint\n",
+    "tftext_endpoint = client.get_or_create_endpoint(\"tf-text-clf-v1\")\n",
+    "tftext_endpoint.update(model_version_from_cls, wait=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get deployed model from endpoint\n",
+    "deployed_model = tftext_endpoint.get_deployed_model()\n",
+    "deployed_model.predict(sample_pred)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete endpoint after use\n",
+    "tftext_endpoint.delete()"
    ]
   }
  ],
@@ -503,7 +632,7 @@
    "version": "0.3.2"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -517,7 +646,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "06c1a21831df6a440f2d42eb85c06be085732911c14ae508e0185f4137c7dc29"
+   }
   }
  },
  "nbformat": 4,

--- a/end-to-end/tensorflow/tfhub-text-classification.ipynb
+++ b/end-to-end/tensorflow/tfhub-text-classification.ipynb
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },
@@ -62,8 +62,12 @@
     "# Python 3.6\n",
     "!pip install verta\n",
     "!pip install matplotlib==3.1.1\n",
+    "# for macos\n",
+    "# !pip install tensorflow-macos\n",
+    "# !pip install -U tensorflow-hub\n",
+    "# else\n",
     "!pip install tensorflow==2.0.0-beta1\n",
-    "!pip install tensorflow-hub==0.5.0\n",
+    "!pip install -U tensorflow-hub==0.5.0\n",
     "!pip install tensorflow-datasets==1.0.2"
    ]
   },
@@ -76,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -170,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -202,7 +206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -226,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -253,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -279,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -313,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -335,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -362,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -382,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -410,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -443,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -491,6 +495,128 @@
    "source": [
     "sample_pred = np.array([\"The new Spiderman movie is a fun watch. Loved it!\"])\n",
     "model.predict(sample_pred)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Registering the model"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since the model uses CustomObject (i.e KerasLayer from tensorflow_hub) we have to register the model into the catalogue using a serialized version of the model using the VertaModelBase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "registered_model = client.get_or_create_registered_model(\n",
+    "    name=\"text-clf\", labels=[\"nlp\", \"tensorflow\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.save('tfhub_text.tf_saved_model', save_format='tf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from verta.registry import VertaModelBase\n",
+    "\n",
+    "class TFHubModel(VertaModelBase):\n",
+    "    def __init__(self, artifacts):\n",
+    "        import tensorflow as tf\n",
+    "        import tensorflow_hub as tfhub\n",
+    "        self.model = tf.keras.models.load_model(\n",
+    "            artifacts[\"tf-clf\"], custom_objects={'KerasLayer': tfhub.KerasLayer})\n",
+    "    \n",
+    "    def predict(self, input_data):\n",
+    "        if type(input_data) == list:\n",
+    "            input_data = np.array(input_data)\n",
+    "        return list(self.model.predict(input_data).reshape((-1)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# test locally\n",
+    "artifacts = {\"tf-clf\" : \"tfhub_text.tf_saved_model/\"}\n",
+    "mnist_model1 = TFHubModel(artifacts)\n",
+    "mnist_model1.predict(list(sample_pred))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# register model\n",
+    "from verta.environment import Python\n",
+    "\n",
+    "model_version_from_cls = registered_model.create_standard_model(\n",
+    "    TFHubModel, \n",
+    "    environment=Python([\"tensorflow\", \"tensorflow-hub\"]),\n",
+    "    name=\"v2\", \n",
+    "    artifacts=artifacts\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Deploy the Model to Endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tftext_endpoint = client.get_or_create_endpoint(\"tf-text-clf-v1\")\n",
+    "tftext_endpoint.update(model_version_from_cls, wait=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deployed_model = tftext_endpoint.get_deployed_model()\n",
+    "deployed_model.predict(sample_pred)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tftext_endpoint.delete()"
    ]
   }
  ],
@@ -503,7 +629,7 @@
    "version": "0.3.2"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -517,7 +643,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "06c1a21831df6a440f2d42eb85c06be085732911c14ae508e0185f4137c7dc29"
+   }
   }
  },
  "nbformat": 4,

--- a/end-to-end/tensorflow/tfhub-text-classification.ipynb
+++ b/end-to-end/tensorflow/tfhub-text-classification.ipynb
@@ -63,8 +63,8 @@
     "!pip install verta\n",
     "!pip install matplotlib==3.1.1\n",
     "# for macos\n",
-    "# !pip install tensorflow-macos\n",
-    "# !pip install -U tensorflow-hub\n",
+    "# !pip install tensorflow-macos==2.11.0\n",
+    "# !pip install -U tensorflow-hub==0.12.0\n",
     "# else\n",
     "!pip install tensorflow==2.0.0-beta1\n",
     "!pip install -U tensorflow-hub==0.5.0\n",
@@ -84,35 +84,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HOST = 'app.verta.ai'\n",
-    "\n",
-    "PROJECT_NAME = 'Text-Classification'\n",
-    "EXPERIMENT_NAME = 'basic-clf'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# import os\n",
-    "# os.environ['VERTA_EMAIL'] = \n",
-    "# os.environ['VERTA_DEV_KEY'] = "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "from verta import Client\n",
     "from verta.utils import ModelAPI\n",
     "\n",
-    "client = Client(HOST, use_git=False)\n",
+    "# Use local env vars or uncomment and fill out the lines below:\n",
+    "# os.environ['VERTA_EMAIL'] = ''\n",
+    "# os.environ['VERTA_DEV_KEY'] = ''\n",
+    "# os.environ['VERTA_HOST'] = ''\n",
     "\n",
-    "proj = client.set_project(PROJECT_NAME)\n",
+    "client: Client = Client()\n",
+    "\n",
+    "# Naming convention to be used for this example\n",
+    "NAME: str = 'tfhub-text-classification-example'\n",
+    "\n",
+    "EXPERIMENT_NAME: str = 'gnews-swivel-20dim-clf'\n",
+    "\n",
+    "proj = client.set_project(NAME)\n",
     "expt = client.set_experiment(EXPERIMENT_NAME)\n",
     "run = client.set_experiment_run()"
    ]
@@ -506,6 +493,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "registered_model = client.get_or_create_registered_model(\n",
+    "    name=\"text-clf-example\", labels=[\"nlp\", \"tensorflow\"])"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -519,17 +516,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "registered_model = client.get_or_create_registered_model(\n",
-    "    name=\"text-clf\", labels=[\"nlp\", \"tensorflow\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.save('tfhub_text.tf_saved_model', save_format='tf')"
+    "# save model locally\n",
+    "\n",
+    "# Uncomment if tf saved model format\n",
+    "model.save('tfhub_text.tf_saved_model', save_format='tf')\n",
+    "\n",
+    "# Uncomment if h5 format\n",
+    "# model.save('tfhub_text.h5', save_format='h5')"
    ]
   },
   {
@@ -544,8 +537,10 @@
     "    def __init__(self, artifacts):\n",
     "        import tensorflow as tf\n",
     "        import tensorflow_hub as tfhub\n",
+    "\n",
+    "        # custom_objects need to be defined while loading/deserializing the model \n",
     "        self.model = tf.keras.models.load_model(\n",
-    "            artifacts[\"tf-clf\"], custom_objects={'KerasLayer': tfhub.KerasLayer})\n",
+    "            artifacts[\"text_clf\"], custom_objects={'KerasLayer': tfhub.KerasLayer})\n",
     "    \n",
     "    def predict(self, input_data):\n",
     "        if type(input_data) == list:\n",
@@ -560,9 +555,15 @@
    "outputs": [],
    "source": [
     "# test locally\n",
-    "artifacts = {\"tf-clf\" : \"tfhub_text.tf_saved_model/\"}\n",
-    "mnist_model1 = TFHubModel(artifacts)\n",
-    "mnist_model1.predict(list(sample_pred))"
+    "\n",
+    "# Uncomment if tf saved model format\n",
+    "artifacts = {\"text_clf\" : \"tfhub_text.tf_saved_model/\"}\n",
+    "\n",
+    "# Uncomment if h5 format\n",
+    "# artifacts = {\"text_clf\" : \"tfhub_text.h5\"}\n",
+    "\n",
+    "tfhub_text_model1 = TFHubModel(artifacts)\n",
+    "tfhub_text_model1.predict(list(sample_pred))"
    ]
   },
   {
@@ -571,13 +572,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# register model\n",
+    "# upload model to registry\n",
     "from verta.environment import Python\n",
     "\n",
     "model_version_from_cls = registered_model.create_standard_model(\n",
     "    TFHubModel, \n",
     "    environment=Python([\"tensorflow\", \"tensorflow-hub\"]),\n",
-    "    name=\"v2\", \n",
+    "    name=\"v1\", \n",
     "    artifacts=artifacts\n",
     ")"
    ]
@@ -596,7 +597,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tftext_endpoint = client.get_or_create_endpoint(\"tf-text-clf-v1\")\n",
+    "# create endpoint and update to deploy model\n",
+    "tftext_endpoint = client.get_or_create_endpoint(\"tf-text-clf-example-v1\")\n",
     "tftext_endpoint.update(model_version_from_cls, wait=True)"
    ]
   },
@@ -606,6 +608,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# get deployed model from endpoint\n",
     "deployed_model = tftext_endpoint.get_deployed_model()\n",
     "deployed_model.predict(sample_pred)"
    ]
@@ -616,6 +619,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# delete endpoint\n",
     "tftext_endpoint.delete()"
    ]
   }


### PR DESCRIPTION
## Impact and Context

Absence of deployment piece of code in the examples for end-to-end/tensorflow/tfhub-text-classification.ipynb and deployment/tfhub/tfhub-text-classification.ipynb

## Risks and Area of Effect

Guided deployment for tfhub based models for text classification

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) : Python Notebook File 

## Reverting
- [ ] Contains Migration - _Do Not Revert_