### PR TITLE
fix: Add apt packages for Pillow

### DIFF
--- a/deployment/tfhub/object-detection-base64.ipynb
+++ b/deployment/tfhub/object-detection-base64.ipynb
@@ -292,9 +292,9 @@
       "outputs": [],
       "source": [
         "model = registered_model.create_standard_model(\n",
-        "    name = VERSION,\n",
-        "    model_cls = DetectObject,\n",
-        "    model_api = ModelAPI(\n",
+        "    name=VERSION,\n",
+        "    model_cls=DetectObject,\n",
+        "    model_api=ModelAPI(\n",
         "        [{'file_name': '', 'img': ''}],\n",
         "        [{\n",
         "            'file_name': '',\n",
@@ -304,13 +304,16 @@
         "                'ymin': 0,\n",
         "                'xmin': 0,\n",
         "                'ymax': 0,\n",
-        "                'xmax': 0\n",
+        "                'xmax': 0,\n",
         "            }\n",
         "        }]\n",
         "    ),\n",
-        "    environment = Python(requirements = ['tensorflow', 'tensorflow_hub', 'dill', 'Pillow', 'wget'])\n",
+        "    environment=Python(\n",
+        "        requirements=['tensorflow', 'tensorflow_hub', 'dill', 'Pillow', 'wget'],\n",
+        "        apt_packages=['libjpeg-dev', 'zlib1g-dev'],  # for Pillow\n",
+        "    )\n",
         ")"
-      ]
+       ]
     },
     {
       "cell_type": "markdown",

--- a/deployment/tfhub/object-detection-base64.ipynb
+++ b/deployment/tfhub/object-detection-base64.ipynb
@@ -313,7 +313,7 @@
         "        apt_packages=['libjpeg-dev', 'zlib1g-dev'],  # for Pillow\n",
         "    )\n",
         ")"
-       ]
+      ]
     },
     {
       "cell_type": "markdown",

--- a/deployment/tfhub/object-detection-url.ipynb
+++ b/deployment/tfhub/object-detection-url.ipynb
@@ -340,7 +340,7 @@
         "        apt_packages=['libjpeg-dev', 'zlib1g-dev'],  # for Pillow\n",
         "    )\n",
         ")"
-       ]
+      ]
     },
     {
       "cell_type": "markdown",

--- a/deployment/tfhub/object-detection-url.ipynb
+++ b/deployment/tfhub/object-detection-url.ipynb
@@ -319,9 +319,9 @@
       "outputs": [],
       "source": [
         "model = registered_model.create_standard_model(\n",
-        "    name = VERSION,\n",
-        "    model_cls = DetectObject,\n",
-        "    model_api = ModelAPI(\n",
+        "    name=VERSION,\n",
+        "    model_cls=DetectObject,\n",
+        "    model_api=ModelAPI(\n",
         "        [{'file_name': '', 'url': ''}],\n",
         "        [{\n",
         "            'file_name': '',\n",
@@ -331,13 +331,16 @@
         "                'ymin': 0,\n",
         "                'xmin': 0,\n",
         "                'ymax': 0,\n",
-        "                'xmax': 0\n",
+        "                'xmax': 0,\n",
         "            }\n",
         "        }]\n",
         "    ),\n",
-        "    environment = Python(requirements = ['tensorflow', 'tensorflow_hub', 'dill', 'Pillow', 'wget'])\n",
+        "    environment=Python(\n",
+        "        requirements=['tensorflow', 'tensorflow_hub', 'dill', 'Pillow', 'wget'],\n",
+        "        apt_packages=['libjpeg-dev', 'zlib1g-dev'],  # for Pillow\n",
+        "    )\n",
         ")"
-      ]
+       ]
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
<!-- Example Title: "fix: [JIRA-123] Allow creation of groups with no members" -->
## Impact and Context

_Possibly_ because we changed our base images from Ubuntu to Debian, our endpoints seem to no longer have the dependencies necessary to install `Pillow`.

## Risks and Area of Effect
- [ ] Is this a breaking change?

—

## Testing
- [ ] Unit test
- [ ] Deployed to dev env
- [x] Other (explain) 

Ran end to end in Colab

## Reverting
- [ ] Contains Migration - _Do Not Revert_

Revert this PR.